### PR TITLE
Remove checkpoint_dir check when converting weights

### DIFF
--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -62,8 +62,6 @@ def convert_hf_checkpoint(
     model_name: Optional[str] = None,
     dtype: str = "float32",
 ) -> None:
-    check_valid_checkpoint_dir(checkpoint_dir)
-
     dt = getattr(torch, dtype, None)
     if not isinstance(dt, torch.dtype):
         raise ValueError(f"{dtype} is not a valid dtype.")

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -79,7 +79,10 @@ def convert_hf_checkpoint(
     # initialize a new empty state dict to hold our new weights
     sd = model.state_dict()
 
-    for bin_file in sorted(checkpoint_dir.glob("*.bin")):
+    bin_files = checkpoint_dir.glob("*.bin")
+    if not bin_files:
+        raise ValueError(f"Expected {str(checkpoint_dir)!r} to contain .bin files")
+    for bin_file in sorted(bin_files):
         print("Processing", bin_file)
         hf_weights = torch.load(bin_file, map_location="cpu")
         copy_weights(sd, hf_weights, dtype=dtype)


### PR DESCRIPTION
Closes https://github.com/Lightning-AI/lit-llama/pull/250

This check is misplaced, as this is the function that is meant to save the weights.