### PR TITLE
Cleanup reply output in chat.py

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -159,6 +159,7 @@ def main(
                 print(tokenizer.decode(token), end="", flush=True)
                 tokens_generated += 1
             t = time.perf_counter() - t0
+            print()
             print(f"Time for inference: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec", file=sys.stderr)
         except KeyboardInterrupt:
             # support stopping generation


### PR DESCRIPTION
Currently, there is no spacing between the reply output and the `Time for inference: ...` output. Added a print statement to separate the two.