### PR TITLE
Set dtype of kv_caches correctly

### DIFF
--- a/lit_parrot/model.py
+++ b/lit_parrot/model.py
@@ -94,7 +94,8 @@ class Parrot(nn.Module):
                 )
                 v_cache_shape = (B, self.config.n_head, max_seq_length, head_size)
                 self.kv_caches = [
-                    (torch.zeros(k_cache_shape, device=idx.device), torch.zeros(v_cache_shape, device=idx.device))
+                    (torch.zeros(k_cache_shape, device=x.device, dtype=x.dtype),
+                     torch.zeros(v_cache_shape, device=x.device, dtype=x.dtype))
                     for _ in range(self.config.n_layer)
                 ]
             for i, block in enumerate(self.transformer.h):


### PR DESCRIPTION
Right now the cache defaulted to the `default_tensor_dtype`, here we set it to the type of the input of `block`.