### PR TITLE
Fix max_iters logic

### DIFF
--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -16,7 +16,7 @@ from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600
 save_interval = 1000
-eval_batches = 100
+eval_iters = 100
 log_interval = 1
 devices = 1
 
@@ -139,8 +139,8 @@ def train(
 def validate(fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
-    losses = torch.zeros(eval_batches)
-    for k in range(eval_batches):
+    losses = torch.zeros(eval_iters)
+    for k in range(eval_iters):
         input_ids, targets = get_batch(fabric, val_data)
         logits = model(input_ids)
         loss = loss_fn(logits, targets)

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -25,6 +25,7 @@ learning_rate = 9e-3
 batch_size = 64 / devices
 micro_batch_size = 4
 gradient_accumulation_steps = batch_size // micro_batch_size
+assert gradient_accumulation_steps > 0
 epoch_size = 50000  # train dataset size
 num_epochs = 5
 max_batches = num_epochs * (epoch_size // micro_batch_size) // devices

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -30,7 +30,7 @@ num_epochs = 5
 max_batches = num_epochs * (epoch_size // micro_batch_size) // devices
 weight_decay = 0.02
 max_seq_length = 256  # see scripts/prepare_alpaca.py
-warmup_steps = epoch_size * 2 // micro_batch_size // devices  # 2 epochs
+warmup_steps = 2 * (epoch_size // micro_batch_size) // devices  # 2 epochs
 
 ds_config = {
     "train_micro_batch_size_per_gpu": micro_batch_size,

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -28,10 +28,10 @@ gradient_accumulation_steps = batch_size // micro_batch_size
 assert gradient_accumulation_steps > 0
 epoch_size = 50000  # train dataset size
 num_epochs = 5
-max_batches = num_epochs * (epoch_size // micro_batch_size) // devices
+max_iters = num_epochs * (epoch_size // micro_batch_size) // devices
 weight_decay = 0.02
 max_seq_length = 256  # see scripts/prepare_alpaca.py
-warmup_steps = 2 * (epoch_size // micro_batch_size) // devices  # 2 epochs
+warmup_iters = 2 * (epoch_size // micro_batch_size) // devices  # 2 epochs
 
 ds_config = {
     "train_micro_batch_size_per_gpu": micro_batch_size,
@@ -98,10 +98,10 @@ def train(
 
     tokenizer = Tokenizer(checkpoint_dir / "tokenizer.json", checkpoint_dir / "tokenizer_config.json")
 
-    for iter_num in range(max_batches):
-        if step_count <= warmup_steps:
+    for iter_num in range(max_iters):
+        if step_count <= warmup_iters:
             # linear warmup
-            lr = learning_rate * step_count / warmup_steps
+            lr = learning_rate * step_count / warmup_iters
             for param_group in optimizer.param_groups:
                 param_group["lr"] = lr
 

--- a/generate.py
+++ b/generate.py
@@ -40,8 +40,6 @@ def generate(
     T_new = T + max_new_tokens
     if max_seq_length is None:
         max_seq_length = min(T_new, model.config.block_size)
-   
-
 
     device, dtype = idx.device, idx.dtype
     # create an empty tensor of the expected final shape and fill in the current tokens

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -27,14 +27,14 @@ log_interval = 1
 learning_rate = 6e-4
 batch_size = 125
 micro_batch_size = 5
-max_batches = 600000  # num_epochs * (epoch_size // micro_batch_size) // devices
+max_iters = 600000  # num_epochs * (epoch_size // micro_batch_size) // devices
 weight_decay = 1e-1
 beta1 = 0.9
 beta2 = 0.95
 grad_clip = 1.0
 decay_lr = True
-warmup_batches = 2000
-lr_decay_batches = max_batches
+warmup_iters = 2000
+lr_decay_iters = max_iters
 min_lr = 6e-5
 
 
@@ -195,7 +195,7 @@ def train(
             tokens = 0
             step_time = 0.0
 
-        if iter_num > max_batches:
+        if iter_num > max_iters:
             break
 
 
@@ -286,13 +286,13 @@ def create_dataloaders(
 # learning rate decay scheduler (cosine with warmup)
 def get_lr(it):
     # 1) linear warmup for warmup_iters steps
-    if it < warmup_batches:
-        return learning_rate * it / warmup_batches
+    if it < warmup_iters:
+        return learning_rate * it / warmup_iters
     # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_batches:
+    if it > lr_decay_iters:
         return min_lr
     # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_batches) / (lr_decay_batches - warmup_batches)
+    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -27,14 +27,14 @@ log_interval = 1
 learning_rate = 6e-4
 batch_size = 125
 micro_batch_size = 5
-max_iters = 600000  # num_epochs * epoch_size // devices
+max_batches = 600000  # num_epochs * (epoch_size // micro_batch_size) // devices
 weight_decay = 1e-1
 beta1 = 0.9
 beta2 = 0.95
 grad_clip = 1.0
 decay_lr = True
-warmup_iters = 2000
-lr_decay_iters = max_iters
+warmup_batches = 2000
+lr_decay_batches = max_batches
 min_lr = 6e-5
 
 
@@ -195,7 +195,7 @@ def train(
             tokens = 0
             step_time = 0.0
 
-        if iter_num > max_iters:
+        if iter_num > max_batches:
             break
 
 
@@ -286,13 +286,13 @@ def create_dataloaders(
 # learning rate decay scheduler (cosine with warmup)
 def get_lr(it):
     # 1) linear warmup for warmup_iters steps
-    if it < warmup_iters:
-        return learning_rate * it / warmup_iters
+    if it < warmup_batches:
+        return learning_rate * it / warmup_batches
     # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_iters:
+    if it > lr_decay_batches:
         return min_lr
     # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+    decay_ratio = (it - warmup_batches) / (lr_decay_batches - warmup_batches)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)


### PR DESCRIPTION
Changes:
- Fix max_iters to account for the `micro_batch_size`, as the `epoch_size` is defined as the length of the dataset, not the length of the dataloader

The same issues exist in Lit-LlaMA.