### PR TITLE
Updated TPU docs to download nightly torch dependencies

### DIFF
--- a/howto/tpus.md
+++ b/howto/tpus.md
@@ -18,14 +18,15 @@ pip install -r requirements.txt
 ```
 
 Install Optimized BLAS
-```
+
+```shell
 sudo apt update
 sudo apt install libopenblas-dev
 ```
 
 Since Lit-Parrot requires a torch version newer than torch 2.0.0, we need to manually install nightly builds of torch and torch_xla:
 
-```
+```shell
 pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl
 pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl
 ```

--- a/howto/tpus.md
+++ b/howto/tpus.md
@@ -20,7 +20,6 @@ pip install -r requirements.txt
 Since Lit-Parrot requires a torch version newer than torch 2.0.0, we need to manually install nightly builds of torch, torch_xla, and torchvision:
 
 ```
-pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torchvision-nightly-cp38-cp38-linux_x86_64.whl
 pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl
 pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl
 ```

--- a/howto/tpus.md
+++ b/howto/tpus.md
@@ -17,7 +17,7 @@ cd lit-parrot
 pip install -r requirements.txt
 ```
 
-Since Lit-Parrot requires a torch version newer than torch 2.0.0, we need to manually install nightly builds of torch, torch_xla, and torchvision:
+Since Lit-Parrot requires a torch version newer than torch 2.0.0, we need to manually install nightly builds of torch and torch_xla:
 
 ```
 pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl

--- a/howto/tpus.md
+++ b/howto/tpus.md
@@ -17,6 +17,12 @@ cd lit-parrot
 pip install -r requirements.txt
 ```
 
+Install Optimized BLAS
+```
+sudo apt update
+sudo apt install libopenblas-dev
+```
+
 Since Lit-Parrot requires a torch version newer than torch 2.0.0, we need to manually install nightly builds of torch and torch_xla:
 
 ```

--- a/howto/tpus.md
+++ b/howto/tpus.md
@@ -5,7 +5,7 @@ This project uses `lightning.Fabric` under the hood, which itself supports TPUs 
 The following commands will allow you to set up a `Google Cloud` instance with a [TPU v4](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm) VM:
 
 ```shell
-gcloud compute tpus tpu-vm create lit-parrot --version=tpu-vm-v4-pt-2.0 --accelerator-type=v4-8 --zone=us-central2-b
+gcloud compute tpus tpu-vm create lit-parrot --version=tpu-vm-v4-base --accelerator-type=v4-8 --zone=us-central2-b
 gcloud compute tpus tpu-vm ssh lit-parrot --zone=us-central2-b
 ```
 
@@ -15,6 +15,14 @@ Now that you are in the machine, let's clone the repository and install the depe
 git clone https://github.com/Lightning-AI/lit-parrot
 cd lit-parrot
 pip install -r requirements.txt
+```
+
+Since Lit-Parrot requires a torch version newer than torch 2.0.0, we need to manually install nightly builds of torch, torch_xla, and torchvision:
+
+```
+pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torchvision-nightly-cp38-cp38-linux_x86_64.whl
+pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl
+pip install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl
 ```
 
 By default, computations will run using the new (and experimental) PjRT runtime. Still, it's recommended that you set the following environment variables


### PR DESCRIPTION
This minor documentation change is needed because lit parrot requires torch newer than 2.0.0. Once there is a newer version available when creating cloud TPUs, we can remove these installations.