### PR TITLE
Reset all caches on xla devices

### DIFF
--- a/lit_parrot/adapter.py
+++ b/lit_parrot/adapter.py
@@ -171,11 +171,8 @@ class Parrot(BaseModel):
         self.adapter_kv_caches: List[KVCache] = []
 
     def reset_cache(self) -> None:
-        self.kv_caches.clear()
+        super().reset_cache()
         self.adapter_kv_caches.clear()
-        if self.mask_cache.device.type == "xla":
-            self.rope_cache = None
-            self.mask_cache = None
 
     def forward(
         self, idx: torch.Tensor, max_seq_length: Optional[int] = None, input_pos: Optional[torch.Tensor] = None

--- a/lit_parrot/adapter.py
+++ b/lit_parrot/adapter.py
@@ -173,6 +173,9 @@ class Parrot(BaseModel):
     def reset_cache(self) -> None:
         self.kv_caches.clear()
         self.adapter_kv_caches.clear()
+        if self.mask_cache.device.type == "xla":
+            self.rope_cache = None
+            self.mask_cache = None
 
     def forward(
         self, idx: torch.Tensor, max_seq_length: Optional[int] = None, input_pos: Optional[torch.Tensor] = None

--- a/lit_parrot/model.py
+++ b/lit_parrot/model.py
@@ -52,6 +52,7 @@ class Parrot(nn.Module):
     def reset_cache(self) -> None:
         self.kv_caches.clear()
         if self.mask_cache.device.type == "xla":
+            # https://github.com/Lightning-AI/lit-parrot/pull/83#issuecomment-1558150179
             self.rope_cache = None
             self.mask_cache = None
 

--- a/lit_parrot/model.py
+++ b/lit_parrot/model.py
@@ -51,6 +51,9 @@ class Parrot(nn.Module):
 
     def reset_cache(self) -> None:
         self.kv_caches.clear()
+        if self.mask_cache.device.type == "xla":
+            self.rope_cache = None
+            self.mask_cache = None
 
     def forward(
         self, idx: torch.Tensor, max_seq_length: Optional[int] = None, input_pos: Optional[torch.Tensor] = None


### PR DESCRIPTION
On `xla` devices, we want to also reset `rope_cache` and `mask_cache` in `reset_cache()`. Rational is explained in https://github.com/Lightning-AI/lit-parrot/pull/83#issuecomment-1558150179