### PR TITLE
Be able to set custom accelerator, precision and dtype for MPS accelerators (Apple M1 silicon)

### DIFF
--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -43,14 +43,17 @@ def main(
     data_dir: Path = Path("data/alpaca"),
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/adapter/alpaca"),
+    accelerator = "cuda",
+    precision = "bf16-mixed",
+    dtype= "bfloat16",
 ):
     check_valid_checkpoint_dir(checkpoint_dir)
 
     fabric = L.Fabric(
-        accelerator="cuda",
+        accelerator=accelerator,
         devices=devices,
         strategy=(DeepSpeedStrategy(config=ds_config) if devices > 1 else "auto"),
-        precision="bf16-mixed",
+        precision=precision,
     )
     fabric.launch()
     fabric.seed_everything(1337 + fabric.global_rank)
@@ -62,7 +65,7 @@ def main(
 
     config = Config.from_name(name=checkpoint_dir.name, block_size=max_seq_length)
 
-    with EmptyInitOnDevice(device=fabric.device, dtype=torch.bfloat16):
+    with EmptyInitOnDevice(device=fabric.device, dtype=torch.float32 if dtype == "float32" else torch.bfloat16):
         model = Parrot(config)
     with lazy_load(checkpoint_dir / "lit_model.pth") as checkpoint:
         model.load_state_dict(checkpoint, strict=False)
@@ -183,7 +186,7 @@ def get_batch(fabric: L.Fabric, data: list):
 
     x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
     y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
-    x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
+    x, y = fabric.to_device((x, y))
 
     return x, y
 

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -186,7 +186,11 @@ def get_batch(fabric: L.Fabric, data: list):
 
     x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
     y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
-    x, y = fabric.to_device((x, y))
+
+    if fabric._accelerator.__class__.__name__ == "MPSAccelerator":
+        x, y = fabric.to_device((x, y))
+    else: 
+        x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
 
     return x, y
 


### PR DESCRIPTION
To make the finetuning work on mac Metal Performance Shaders (MPS) accelerators with custom command line arguments such as:

```
python finetune_adapter.py --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b --accelerator mps --precision 32-true --dtype float32
```

