### PR TITLE
Fix to point to correct generation script in Falcon documentation

### DIFF
--- a/howto/download_falcon.md
+++ b/howto/download_falcon.md
@@ -34,5 +34,5 @@ python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/tiiuae/falc
 You're done! To execute the model just run:
 
 ```bash
-python generate.py --prompt "Hello, my name is" --checkpoint_dir checkpoints/tiiuae/falcon-7b
+python generate/base.py --prompt "Hello, my name is" --checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```


### PR DESCRIPTION
This is a small bugfix, looks like generate.py was renamed.