### PR TITLE
[TPU] XLA changes for finetuning

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -64,10 +64,10 @@ def setup(
 
 
 def main(
+    fabric: L.Fabric = None,
     data_dir: Path = Path("data/alpaca"),
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/adapter/alpaca"),
-    fabric: L.Fabric = None,
 ):
     check_valid_checkpoint_dir(checkpoint_dir)
     fabric.seed_everything(1337 + fabric.global_rank)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -223,7 +223,7 @@ def get_batch(fabric: L.Fabric, data: list):
     x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
     y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
 
-    if isinstance(fabric.accelerator, MPSAccelerator) or fabric.device.type == 'xla':
+    if fabric.device.type in ("mps", "xla"):
         x, y = fabric.to_device((x, y))
     else:
         x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -63,12 +63,7 @@ def setup(
         devices=devices, strategy=strategy, precision="32-true" if tpu else precision
     )
     
-    if tpu:
-        p_main = functools.partial(main, data_dir, checkpoint_dir, out_dir)
-        fabric.launch(p_main)
-    else:
-        fabric.launch()
-        main(data_dir, checkpoint_dir, out_dir, fabric)
+    fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 
 
 def main(

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -59,6 +59,8 @@ def setup(
         if devices <= 1
         else XLAStrategy(sync_module_states=False) if tpu else DeepSpeedStrategy(config=ds_config)
     )
+    # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.
+    devices = "auto" if (tpu and devices > 1) else devices
     fabric = L.Fabric(devices=devices, strategy=strategy, precision="32-true" if tpu else precision)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -4,7 +4,7 @@ import sys
 import time
 import warnings
 from pathlib import Path
-from typing import Literal
+from typing import Optional
 
 import lightning as L
 import numpy as np
@@ -51,9 +51,11 @@ def setup(
     data_dir: Path = Path("data/alpaca"),
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/adapter/alpaca"),
-    precision: str = "bf16-true",
+    precision: Optional[str] = None,
     tpu: bool = False,
 ):
+    if precision is None:
+        precision = "32-true" if tpu else "16-true"
     strategy = (
         "auto"
         if devices <= 1
@@ -61,7 +63,7 @@ def setup(
     )
     # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.
     fabric_devices = "auto" if (tpu and devices > 1) else devices
-    fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision="32-true" if tpu else precision)
+    fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 
 

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -57,11 +57,9 @@ def setup(
     strategy = (
         "auto"
         if devices <= 1
-        else (XLAStrategy(sync_module_states=False)) if tpu else DeepSpeedStrategy(config=ds_config)
+        else XLAStrategy(sync_module_states=False) if tpu else DeepSpeedStrategy(config=ds_config)
     )
-
     fabric = L.Fabric(devices=devices, strategy=strategy, precision="32-true" if tpu else precision)
-
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 
 
@@ -262,10 +260,10 @@ if __name__ == "__main__":
     # torch.backends.cuda.enable_flash_sdp(False)
     torch.set_float32_matmul_precision("high")
 
+    from jsonargparse.cli import CLI
     warnings.filterwarnings(
         # false positive using deepspeed: https://github.com/Lightning-AI/lightning/pull/17761#discussion_r1219705307
         "ignore", message="Remove `.no_backward_sync()` from your code",
     )
-    from jsonargparse.cli import CLI
 
     CLI(setup)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -137,15 +137,10 @@ def train(
 
         input_ids, targets = get_batch(fabric, train_data)
 
-        if fabric.device.type == "xla":
+        with fabric.no_backward_sync(model, enabled=((iter_num + 1) % gradient_accumulation_steps != 0)):
             logits = model(input_ids)
             loss = loss_fn(logits, targets)
             fabric.backward(loss / gradient_accumulation_steps)
-        else:
-            with fabric.no_backward_sync(model, enabled=((iter_num + 1) % gradient_accumulation_steps != 0)):
-                logits = model(input_ids)
-                loss = loss_fn(logits, targets)
-                fabric.backward(loss / gradient_accumulation_steps)
 
         if (iter_num + 1) % gradient_accumulation_steps == 0:
             optimizer.step()

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -60,8 +60,8 @@ def setup(
         else XLAStrategy(sync_module_states=False) if tpu else DeepSpeedStrategy(config=ds_config)
     )
     # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.
-    devices = "auto" if (tpu and devices > 1) else devices
-    fabric = L.Fabric(devices=devices, strategy=strategy, precision="32-true" if tpu else precision)
+    fabric_devices = "auto" if (tpu and devices > 1) else devices
+    fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision="32-true" if tpu else precision)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 
 

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -2,14 +2,12 @@ import os
 import shutil
 import sys
 import time
-import functools
 from pathlib import Path
 from typing import Literal
 
 import lightning as L
 import numpy as np
 import torch
-from lightning.fabric.accelerators.mps import MPSAccelerator
 from lightning.fabric.strategies import DeepSpeedStrategy, XLAStrategy
 
 # support running without installing as a package

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -4,7 +4,7 @@ import sys
 import time
 import warnings
 from pathlib import Path
-from typing import Literal
+from typing import Optional
 
 import lightning as L
 import numpy as np
@@ -56,10 +56,11 @@ def setup(
     data_dir: Path = Path("data/alpaca"),
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/adapter/alpaca"),
-    precision: str = "bf16-true",
+    precision: Optional[str] = None,
     tpu: bool = False,
-    devices: int = devices,
 ):
+    if precision is None:
+        precision = "32-true" if tpu else "16-true"
     strategy = (
         "auto"
         if devices <= 1
@@ -67,7 +68,7 @@ def setup(
     )
     # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.
     fabric_devices = "auto" if (tpu and devices > 1) else devices
-    fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision="32-true" if tpu else precision)
+    fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 
 

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -9,8 +9,7 @@ from typing import Literal
 import lightning as L
 import numpy as np
 import torch
-from lightning.fabric.accelerators.mps import MPSAccelerator
-from lightning.fabric.strategies import DeepSpeedStrategy
+from lightning.fabric.strategies import DeepSpeedStrategy, XLAStrategy
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -53,18 +52,32 @@ ds_config = {
 }
 
 
+def setup(
+    data_dir: Path = Path("data/alpaca"),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    out_dir: Path = Path("out/adapter/alpaca"),
+    precision: Literal["bf16-true", "32-true"] = "bf16-true",
+    tpu: bool = False,
+    devices: int = devices,
+):
+    strategy = (
+        "auto"
+        if devices <= 1
+        else XLAStrategy(sync_module_states=False) if tpu else DeepSpeedStrategy(config=ds_config)
+    )
+    # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.
+    fabric_devices = "auto" if (tpu and devices > 1) else devices
+    fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision="32-true" if tpu else precision)
+    fabric.launch(main, data_dir, checkpoint_dir, out_dir)
+
+
 def main(
+    fabric: L.Fabric = None,
     data_dir: Path = Path("data/alpaca"),
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/adapter_v2/alpaca"),
-    precision: Literal["bf16-true", "32-true"] = "bf16-true",
 ):
     check_valid_checkpoint_dir(checkpoint_dir)
-
-    fabric = L.Fabric(
-        devices=devices, strategy=(DeepSpeedStrategy(config=ds_config) if devices > 1 else "auto"), precision=precision
-    )
-    fabric.launch()
     fabric.seed_everything(1337 + fabric.global_rank)
 
     if fabric.global_rank == 0:
@@ -114,6 +127,10 @@ def train(
 
     tokenizer = Tokenizer(checkpoint_dir / "tokenizer.json", checkpoint_dir / "tokenizer_config.json")
 
+    if fabric.device.type == "xla":
+        import torch_xla.core.xla_model as xm
+
+        xm.mark_step()
     for iter_num in range(max_iters):
         if step_count <= warmup_iters:
             # linear warmup
@@ -124,6 +141,7 @@ def train(
         t0 = time.time()
 
         input_ids, targets = get_batch(fabric, train_data)
+
         with fabric.no_backward_sync(model, enabled=((iter_num + 1) % gradient_accumulation_iters != 0)):
             logits = model(input_ids)
             loss = loss_fn(logits, targets)
@@ -131,6 +149,8 @@ def train(
 
         if (iter_num + 1) % gradient_accumulation_iters == 0:
             optimizer.step()
+            if fabric.device.type == "xla":
+                xm.mark_step()
             optimizer.zero_grad()
             step_count += 1
 
@@ -144,6 +164,9 @@ def train(
                 print(f"Saving adapter weights to {str(save_path)!r}")
                 # TODO: Provide a function/script to merge the adapter weights with pretrained weights
                 save_model_checkpoint(fabric, model, save_path)
+        else:
+            if fabric.device.type == "xla":
+                xm.mark_step()
 
         dt = time.time() - t0
         if iter_num % log_interval == 0:
@@ -192,7 +215,7 @@ def get_batch(fabric: L.Fabric, data: list):
     input_ids = [data[i]["input_ids"].type(torch.int64) for i in ix]
     labels = [data[i]["labels"].type(torch.int64) for i in ix]
 
-    max_len = max(len(s) for s in input_ids)
+    max_len = max(len(s) for s in input_ids) if fabric.device.type != "xla" else max_seq_length
 
     def pad_right(x, pad_id):
         # pad right based on the longest sequence
@@ -202,7 +225,7 @@ def get_batch(fabric: L.Fabric, data: list):
     x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
     y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
 
-    if isinstance(fabric.accelerator, MPSAccelerator):
+    if fabric.device.type in ("mps", "xla"):
         x, y = fabric.to_device((x, y))
     else:
         x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
@@ -249,4 +272,4 @@ if __name__ == "__main__":
         # false positive using deepspeed: https://github.com/Lightning-AI/lightning/pull/17761#discussion_r1219705307
         "ignore", message="Remove `.no_backward_sync()` from your code",
     )
-    CLI(main)
+    CLI(setup)


### PR DESCRIPTION
This PR adds changes specific for finetuning on TPUs. 
Used TPU v4-8 with
```
log_interval = 1
devices = 4
batch_size = 64 / devices
micro_batch_size = 4
gradient_accumulation_steps = 4
num_epochs = 5
```

for stablelm-base-alpha-3b; resulting finetuning time ~= 4500s.