### PR TITLE
Set the config's block size  as the max_seq_length data preparation and fine tuning scripts

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -1,11 +1,10 @@
-import json
 import os
 import shutil
 import sys
 import time
 import warnings
 from pathlib import Path
-from typing import Optional, Literal
+
 
 import lightning as L
 import numpy as np
@@ -91,13 +90,14 @@ def main(
 
 
 def train(
-        fabric: L.Fabric,
-        model: torch.nn.Module,
-        optimizer: torch.optim.Optimizer,
-        train_data: np.ndarray,
-        val_data: np.ndarray,
-        checkpoint_dir: Path,
-        out_dir: Path) -> None:
+    fabric: L.Fabric,
+    model: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+    train_data: np.ndarray,
+    val_data: np.ndarray,
+    checkpoint_dir: Path,
+    out_dir: Path,
+) -> None:
     """The training loop.
 
     Loosely based on the nanoGPT implementation: https://github.com/karpathy/nanoGPT.

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -5,7 +5,6 @@ import time
 import warnings
 from pathlib import Path
 
-
 import lightning as L
 import numpy as np
 import torch

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -127,7 +127,7 @@ def train(
             step_count += 1
 
             if step_count % eval_interval == 0:
-                val_loss = validate(fabric, model, val_data, tokenizer, max_seq_length=model.config.block_size)
+                val_loss = validate(fabric, model, val_data, tokenizer)
                 fabric.print(f"step {iter_num}: val loss {val_loss:.4f}")
                 fabric.barrier()
 
@@ -144,7 +144,7 @@ def train(
 
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
+    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
@@ -163,7 +163,7 @@ def validate(
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=model.device)
     output = generate(
-        model, idx=encoded, max_returned_tokens=len(encoded) + 100, max_seq_length=max_seq_length, temperature=0.8
+        model, idx=encoded, max_returned_tokens=len(encoded) + 100, max_seq_length=model.config.block_size, temperature=0.8
     )
     output = tokenizer.decode(output)
     fabric.print(output)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -145,11 +145,8 @@ def train(
 
 @torch.no_grad()
 def validate(
-        fabric: L.Fabric,
-        model: torch.nn.Module,
-        val_data: np.ndarray,
-        tokenizer: Tokenizer,
-        max_seq_length: int) -> torch.Tensor:
+    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
+) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
     losses = torch.zeros(eval_iters)
@@ -167,11 +164,7 @@ def validate(
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=model.device)
     output = generate(
-        model,
-        idx=encoded,
-        max_returned_tokens=len(encoded) + 100,
-        max_seq_length=max_seq_length,
-        temperature=0.8
+        model, idx=encoded, max_returned_tokens=len(encoded) + 100, max_seq_length=max_seq_length, temperature=0.8
     )
     output = tokenizer.decode(output)
     fabric.print(output)
@@ -247,8 +240,10 @@ if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
 
     from jsonargparse.cli import CLI
+
     warnings.filterwarnings(
         # false positive using deepspeed: https://github.com/Lightning-AI/lightning/pull/17761#discussion_r1219705307
-        "ignore", message="Remove `.no_backward_sync()` from your code",
+        "ignore",
+        message="Remove `.no_backward_sync()` from your code",
     )
     CLI(main)

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -1,11 +1,10 @@
-import json
 import os
 import shutil
 import sys
 import time
 import warnings
 from pathlib import Path
-from typing import Optional, Literal
+
 
 import lightning as L
 import numpy as np
@@ -61,7 +60,6 @@ def main(
 ):
     check_valid_checkpoint_dir(checkpoint_dir)
 
-
     fabric = L.Fabric(
         devices=devices, strategy=(DeepSpeedStrategy(config=ds_config) if devices > 1 else "auto"), precision=precision
     )
@@ -99,13 +97,14 @@ def main(
 
 
 def train(
-        fabric: L.Fabric,
-        model: torch.nn.Module,
-        optimizer: torch.optim.Optimizer,
-        train_data: np.ndarray,
-        val_data: np.ndarray,
-        checkpoint_dir: Path,
-        out_dir: Path) -> None:
+    fabric: L.Fabric,
+    model: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+    train_data: np.ndarray,
+    val_data: np.ndarray,
+    checkpoint_dir: Path,
+    out_dir: Path,
+) -> None:
     """The training loop.
 
     Loosely based on the nanoGPT implementation: https://github.com/karpathy/nanoGPT.

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -5,7 +5,6 @@ import time
 import warnings
 from pathlib import Path
 
-
 import lightning as L
 import numpy as np
 import torch

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -133,7 +133,7 @@ def train(
             step_count += 1
 
             if step_count % eval_interval == 0:
-                val_loss = validate(fabric, model, val_data, tokenizer, max_seq_length=model.config.block_size)
+                val_loss = validate(fabric, model, val_data, tokenizer)
                 fabric.print(f"step {iter_num}: val loss {val_loss:.4f}")
                 fabric.barrier()
 
@@ -150,7 +150,7 @@ def train(
 
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
+    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
@@ -169,7 +169,7 @@ def validate(
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=model.device)
     output = generate(
-        model, idx=encoded, max_returned_tokens=len(encoded) + 100, max_seq_length=max_seq_length, temperature=0.8
+        model, idx=encoded, max_returned_tokens=len(encoded) + 100, max_seq_length=model.config.block_size, temperature=0.8
     )
     output = tokenizer.decode(output)
     fabric.print(output)

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -152,11 +152,8 @@ def train(
 
 @torch.no_grad()
 def validate(
-        fabric: L.Fabric,
-        model: torch.nn.Module,
-        val_data: np.ndarray,
-        tokenizer: Tokenizer,
-        max_seq_length: int) -> torch.Tensor:
+    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
+) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
     losses = torch.zeros(eval_iters)
@@ -174,11 +171,7 @@ def validate(
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=model.device)
     output = generate(
-        model,
-        idx=encoded,
-        max_returned_tokens=len(encoded) + 100,
-        max_seq_length=max_seq_length,
-        temperature=0.8
+        model, idx=encoded, max_returned_tokens=len(encoded) + 100, max_seq_length=max_seq_length, temperature=0.8
     )
     output = tokenizer.decode(output)
     fabric.print(output)
@@ -254,8 +247,10 @@ if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
 
     from jsonargparse.cli import CLI
+
     warnings.filterwarnings(
         # false positive using deepspeed: https://github.com/Lightning-AI/lightning/pull/17761#discussion_r1219705307
-        "ignore", message="Remove `.no_backward_sync()` from your code",
+        "ignore",
+        message="Remove `.no_backward_sync()` from your code",
     )
     CLI(main)

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -1,10 +1,11 @@
+import json
 import os
 import shutil
 import sys
 import time
 import warnings
 from pathlib import Path
-from typing import Literal
+from typing import Optional, Literal
 
 import lightning as L
 import numpy as np
@@ -43,7 +44,6 @@ epoch_size = 50000  # train dataset size
 num_epochs = 5
 max_iters = num_epochs * (epoch_size // micro_batch_size) // devices
 weight_decay = 0.02
-max_seq_length = 256  # see scripts/prepare_alpaca.py
 warmup_iters = 2 * (epoch_size // micro_batch_size) // devices  # 2 epochs
 
 ds_config = {
@@ -61,6 +61,7 @@ def main(
 ):
     check_valid_checkpoint_dir(checkpoint_dir)
 
+
     fabric = L.Fabric(
         devices=devices, strategy=(DeepSpeedStrategy(config=ds_config) if devices > 1 else "auto"), precision=precision
     )
@@ -72,7 +73,7 @@ def main(
 
     train_data, val_data = load_datasets(data_dir=data_dir)
 
-    config = Config.from_name(name=checkpoint_dir.name, block_size=max_seq_length)
+    config = Config.from_name(name=checkpoint_dir.name)
     checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
     with fabric.init_module():
@@ -98,14 +99,13 @@ def main(
 
 
 def train(
-    fabric: L.Fabric,
-    model: torch.nn.Module,
-    optimizer: torch.optim.Optimizer,
-    train_data: np.ndarray,
-    val_data: np.ndarray,
-    checkpoint_dir: Path,
-    out_dir: Path,
-) -> None:
+        fabric: L.Fabric,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        train_data: np.ndarray,
+        val_data: np.ndarray,
+        checkpoint_dir: Path,
+        out_dir: Path) -> None:
     """The training loop.
 
     Loosely based on the nanoGPT implementation: https://github.com/karpathy/nanoGPT.
@@ -135,7 +135,7 @@ def train(
             step_count += 1
 
             if step_count % eval_interval == 0:
-                val_loss = validate(fabric, model, val_data, tokenizer)
+                val_loss = validate(fabric, model, val_data, tokenizer, max_seq_length=model.config.block_size)
                 fabric.print(f"step {iter_num}: val loss {val_loss:.4f}")
                 fabric.barrier()
 
@@ -151,7 +151,12 @@ def train(
 
 
 @torch.no_grad()
-def validate(fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer) -> torch.Tensor:
+def validate(
+        fabric: L.Fabric,
+        model: torch.nn.Module,
+        val_data: np.ndarray,
+        tokenizer: Tokenizer,
+        max_seq_length: int) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
     losses = torch.zeros(eval_iters)
@@ -169,7 +174,11 @@ def validate(fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tok
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=model.device)
     output = generate(
-        model, idx=encoded, max_returned_tokens=len(encoded) + 100, max_seq_length=max_seq_length, temperature=0.8
+        model,
+        idx=encoded,
+        max_returned_tokens=len(encoded) + 100,
+        max_seq_length=max_seq_length,
+        temperature=0.8
     )
     output = tokenizer.decode(output)
     fabric.print(output)

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -16,8 +16,6 @@ from lit_parrot import Config
 from lit_parrot.utils import lazy_load, incremental_save
 
 
-
-
 def copy_weights_gpt_neox(state_dict, hf_weights, saver=None, dtype=torch.float32):
     weight_map = {
         "gpt_neox.embed_in.weight": "transformer.wte.weight",

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -16,6 +16,8 @@ from lit_parrot import Config
 from lit_parrot.utils import lazy_load, incremental_save
 
 
+
+
 def copy_weights_gpt_neox(state_dict, hf_weights, saver=None, dtype=torch.float32):
     weight_map = {
         "gpt_neox.embed_in.weight": "transformer.wte.weight",

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -6,7 +6,6 @@ from typing import Optional
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-
 def download_from_hub(repo_id: Optional[str] = None) -> None:
     if repo_id is None:
         from lit_parrot.config import configs

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -6,20 +6,15 @@ from typing import Optional
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
+
 def download_from_hub(repo_id: Optional[str] = None) -> None:
     if repo_id is None:
         from lit_parrot.config import configs
 
-        orgs = {
-            "stablelm": "stabilityai",
-            "pythia": "EleutherAI",
-            "RedPajama": "togethercomputer",
-            "falcon": "tiiuae",
-        }
+        orgs = {"stablelm": "stabilityai", "pythia": "EleutherAI", "RedPajama": "togethercomputer", "falcon": "tiiuae"}
         names = [f"{orgs[el.split('-')[0]]}/{el}" for el in configs.keys()]
 
-        print("Please specify --repo_id <repo_id>. "
-              "Available values:")
+        print("Please specify --repo_id <repo_id>. Available values:")
         print("\n".join(names))
         return
 

--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -44,7 +44,7 @@ def prepare(
     check_valid_checkpoint_dir(checkpoint_dir)
 
     if max_seq_length is None:
-        max_seq_length = torch.load(checkpoint_dir / "lit_config.json")["block_size"]
+        max_seq_length = json.load(checkpoint_dir / "lit_config.json")["block_size"]
 
     destination_path.mkdir(parents=True, exist_ok=True)
     data_file_path = destination_path / data_file_name
@@ -86,7 +86,7 @@ def prepare(
     test_set = [
         prepare_sample(
             example=sample,
-            tokenize=tokenizer, 
+            tokenizer=tokenizer, 
             max_length=max_seq_length, 
             mask_inputs=mask_inputs, 
             ignore_index=ignore_index) 

--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -2,7 +2,6 @@
 import json
 import sys
 from pathlib import Path
-from typing import Optional
 
 import requests
 import torch
@@ -14,7 +13,6 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_parrot.tokenizer import Tokenizer
-from lit_parrot.utils import check_valid_checkpoint_dir
 
 DATA_FILE_URL = "https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cleaned_archive.json"
 DATA_FILE_NAME = "alpaca_data_cleaned_archive.json"
@@ -30,7 +28,6 @@ def prepare(
     destination_path: Path = DESTINATION_PATH,
     checkpoint_dir: Path = CHECKPOINT_DIR,
     test_split_size: int = TEST_SPLIT_SIZE,
-    max_seq_length: Optional[int] = None,  # default will match block_size of checkpoint
     seed: int = SEED,
     mask_inputs: bool = MASK_INPUTS,
     data_file_name: str = DATA_FILE_NAME,
@@ -42,12 +39,9 @@ def prepare(
     The output is a training and validation dataset saved as `train.pt` and `val.pt`,
     which stores the preprocessed and tokenized prompts and labels.
     """
-    check_valid_checkpoint_dir(checkpoint_dir)
-
-    if max_seq_length is None:
-        with open(checkpoint_dir / "lit_config.json", "r") as file:
-            config = json.loads(file.read())
-            max_seq_length = config["block_size"]
+    with open(checkpoint_dir / "lit_config.json", "r") as file:
+        config = json.loads(file.read())
+        max_seq_length = config["block_size"]
 
     destination_path.mkdir(parents=True, exist_ok=True)
     data_file_path = destination_path / data_file_name

--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -45,7 +45,9 @@ def prepare(
     check_valid_checkpoint_dir(checkpoint_dir)
 
     if max_seq_length is None:
-        max_seq_length = json.load(checkpoint_dir / "lit_config.json")["block_size"]
+        with open(checkpoint_dir / "lit_config.json", "r") as file:
+            config = json.loads(file.read())
+            max_seq_length = config["block_size"]
 
     destination_path.mkdir(parents=True, exist_ok=True)
     data_file_path = destination_path / data_file_name

--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -19,19 +19,20 @@ from lit_parrot.utils import check_valid_checkpoint_dir
 DATA_FILE_URL = "https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cleaned_archive.json"
 DATA_FILE_NAME = "alpaca_data_cleaned_archive.json"
 DESTINATION_PATH = Path("data/alpaca")
-CHECKPOINT_DIR =  Path("checkpoints/stabilityai/stablelm-base-alpha-3b")
+CHECKPOINT_DIR = Path("checkpoints/stabilityai/stablelm-base-alpha-3b")
 TEST_SPLIT_SIZE = 2000
 IGNORE_INDEX = -1
-MASK_INPUTS = False     # as in alpaca-lora
+MASK_INPUTS = False  # as in alpaca-lora
 SEED = 42
+
 
 def prepare(
     destination_path: Path = DESTINATION_PATH,
     checkpoint_dir: Path = CHECKPOINT_DIR,
     test_split_size: int = TEST_SPLIT_SIZE,
-    max_seq_length: Optional[int] = None, # default will match block_size of checkpoint 
+    max_seq_length: Optional[int] = None,  # default will match block_size of checkpoint
     seed: int = SEED,
-    mask_inputs: bool = MASK_INPUTS,  
+    mask_inputs: bool = MASK_INPUTS,
     data_file_name: str = DATA_FILE_NAME,
     data_file_url: str = DATA_FILE_URL,
     ignore_index: int = IGNORE_INDEX,
@@ -61,9 +62,7 @@ def prepare(
     # Partition the dataset into train and test
     train_split_size = len(data) - test_split_size
     train_set, test_set = random_split(
-        data,
-        lengths=(train_split_size, test_split_size),
-        generator=torch.Generator().manual_seed(seed)
+        data, lengths=(train_split_size, test_split_size), generator=torch.Generator().manual_seed(seed)
     )
     train_set, test_set = list(train_set), list(test_set)
 
@@ -74,10 +73,11 @@ def prepare(
     train_set = [
         prepare_sample(
             example=sample,
-            tokenizer=tokenizer, 
-            max_length=max_seq_length, 
-            mask_inputs=mask_inputs, 
-            ignore_index=ignore_index) 
+            tokenizer=tokenizer,
+            max_length=max_seq_length,
+            mask_inputs=mask_inputs,
+            ignore_index=ignore_index,
+        )
         for sample in tqdm(train_set)
     ]
     torch.save(train_set, data_file_path.parent / "train.pt")
@@ -86,11 +86,13 @@ def prepare(
     test_set = [
         prepare_sample(
             example=sample,
-            tokenizer=tokenizer, 
-            max_length=max_seq_length, 
-            mask_inputs=mask_inputs, 
-            ignore_index=ignore_index) 
-        for sample in tqdm(test_set)]
+            tokenizer=tokenizer,
+            max_length=max_seq_length,
+            mask_inputs=mask_inputs,
+            ignore_index=ignore_index,
+        )
+        for sample in tqdm(test_set)
+    ]
     torch.save(test_set, data_file_path.parent / "test.pt")
 
 
@@ -103,11 +105,12 @@ def download_if_missing(file_path: Path, file_url: str):
 
 
 def prepare_sample(
-        example: dict, 
-        tokenizer: Tokenizer, 
-        max_length: int, 
-        mask_inputs: bool = MASK_INPUTS,
-        ignore_index: int = IGNORE_INDEX):
+    example: dict,
+    tokenizer: Tokenizer,
+    max_length: int,
+    mask_inputs: bool = MASK_INPUTS,
+    ignore_index: int = IGNORE_INDEX,
+):
     """Processes a single sample.
 
     Each sample in the dataset consists of:
@@ -127,11 +130,7 @@ def prepare_sample(
     full_prompt = generate_prompt(example)
     full_prompt_and_response = full_prompt + example["output"]
     encoded_full_prompt = tokenizer.encode(full_prompt, max_length=max_length)
-    encoded_full_prompt_and_response = tokenizer.encode(
-        full_prompt_and_response, 
-        eos=True,
-        max_length=max_length
-    )
+    encoded_full_prompt_and_response = tokenizer.encode(full_prompt_and_response, eos=True, max_length=max_length)
 
     # The labels are the full prompt with response, but with the prompt masked out
     labels = encoded_full_prompt_and_response.clone()

--- a/scripts/prepare_redpajama.py
+++ b/scripts/prepare_redpajama.py
@@ -1,15 +1,15 @@
-import json
 import glob
+import json
 import os
 from pathlib import Path
 import sys
 
+import numpy as np
+from tqdm import tqdm
+
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
-
-import numpy as np
-from tqdm import tqdm
 
 from lit_parrot import Tokenizer
 import lit_parrot.packed_dataset as packed_dataset


### PR DESCRIPTION
This PR attempts to fix https://github.com/Lightning-AI/lit-parrot/issues/122 by making `max_seq_length` an optional parameter in `scripts/prepare_alpaca.py`, 'finetune/adapter.py` and 'finetune/adapter_v2.py`. 

Currently, all of these scripts use `max_seq_length=256`, which I suspect truncates inputs to the models. There is also an annoying manual dependency between changing this value in one script and then having to make the others match. Instead, this PR uses the `block_size` of the checkpointed model as a default value for `max_seq_length` which can still be manually overridden from the commandline. 

I also changed a few places where functions in `prepare_alpaca.py` had contradictory or confusing default values for arguments and instead expose all the defaults as top-level defined global values which can also be overridden via the CLI. 

@carmocca -- this is still a WIP since I'm just starting to learn how to use both Lightning and the lit-parrot codebase, but curious to get your feedback. 