### PR TITLE
Add datasets to requirements

### DIFF
--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from datasets import load_dataset
 import torch
 
 # support running without installing as a package
@@ -211,7 +212,6 @@ class GPTQQuantizer:
 
 
 def get_sample_data():
-    from datasets import load_dataset
 
     traindata = load_dataset(
         "allenai/c4", "allenai--c4", data_files={"train": "en/c4-train.00000-of-01024.json.gz"}, split="train"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ lightning @ git+https://github.com/Lightning-AI/lightning@master
 tokenizers
 jsonargparse[signatures]  # CLI
 bitsandbytes  # quantize
+datasets # quantize/gptq.py
 zstandard  # prepare_redpajama.py
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ lightning @ git+https://github.com/Lightning-AI/lightning@master
 tokenizers
 jsonargparse[signatures]  # CLI
 bitsandbytes  # quantize
-datasets # quantize/gptq.py
+datasets  # quantize/gptq.py
 zstandard  # prepare_redpajama.py
 


### PR DESCRIPTION
Fixes the `datasets` requirements issue mentioned in #113 .

I also moved the import from the `get_sample_data()` up to the top, because `get_sample_data()` gets called in `main`, which a user would always encounter, if I understand correctly.

(Correct me if I'm wrong @carmocca and the `get_sample_data()` was a temporary debugging thing that should not be there?)



