### PR TITLE
Stricter loading of checkpoints

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -133,7 +133,7 @@ def main(
     with fabric.init_module(empty_init=True), quantization(quantize):
         model = Parrot(config)
     with lazy_load(checkpoint_path) as checkpoint:
-        model.load_state_dict(checkpoint, strict=False)
+        model.load_state_dict(checkpoint, strict=quantize is None)
 
     model.eval()
     model = fabric.setup_module(model)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -86,6 +86,7 @@ def main(
     with fabric.init_module():
         model = Parrot(config)
     with lazy_load(checkpoint_path) as checkpoint:
+        # strict=False because missing keys due to adapter weights not contained in state dict
         model.load_state_dict(checkpoint, strict=False)
 
     mark_only_adapter_as_trainable(model)

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -84,11 +84,9 @@ def main(
     fabric.print(f"Time to instantiate model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     t0 = time.time()
-    with lazy_load(checkpoint_path) as pretrained_checkpoint, lazy_load(adapter_path) as adapter_checkpoint:
-        # 1. Load the pretrained weights
-        model.load_state_dict(pretrained_checkpoint, strict=False)
-        # 2. Load the fine-tuned adapter weights
-        model.load_state_dict(adapter_checkpoint, strict=False)
+    with lazy_load(checkpoint_path) as checkpoint, lazy_load(adapter_path) as adapter_checkpoint:
+        checkpoint.update(adapter_checkpoint)
+        model.load_state_dict(checkpoint, strict=quantize is None)
     fabric.print(f"Time to load the model weights: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -87,11 +87,9 @@ def main(
     fabric.print(f"Time to instantiate model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     t0 = time.time()
-    with lazy_load(checkpoint_path) as pretrained_checkpoint, lazy_load(adapter_path) as adapter_checkpoint:
-        # 1. Load the pretrained weights
-        model.load_state_dict(pretrained_checkpoint, strict=False)
-        # 2. Load the fine-tuned adapter weights
-        model.load_state_dict(adapter_checkpoint, strict=False)
+    with lazy_load(checkpoint_path) as checkpoint, lazy_load(adapter_path) as adapter_checkpoint:
+        checkpoint.update(adapter_checkpoint)
+        model.load_state_dict(checkpoint, strict=quantize is None)
     fabric.print(f"Time to load the model weights: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()

--- a/generate/base.py
+++ b/generate/base.py
@@ -149,7 +149,7 @@ def main(
 
     t0 = time.time()
     with lazy_load(checkpoint_path) as checkpoint:
-        model.load_state_dict(checkpoint, strict=False)
+        model.load_state_dict(checkpoint, strict=quantize is None)
     fabric.print(f"Time to load the model weights: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()


### PR DESCRIPTION
Strict loading is useful as it enforces that your checkpoint gets loaded as you expect.

In the case of the fine-tuned checkpoints, we can merge them to the pre-trained one before loading so that `strict=True` can be used.

Additionally, we only set `strict=False` if quantization is used. This is because of https://github.com/Lightning-AI/lit-parrot/pull/72#issuecomment-1567317405